### PR TITLE
Add .bat file for Windows, allowing 'bother' to be used from the CLI

### DIFF
--- a/scripts/bother.bat
+++ b/scripts/bother.bat
@@ -1,0 +1,4 @@
+:: Windows wrapper for "bother"
+
+@SET "PYTHON_EXE=%~dp0\..\python.exe"
+@call "%PYTHON_EXE%" "%~dp0\bother" %*

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 from setuptools import setup, find_packages
 
 with open('README.md') as f:
     long_description = f.read()
 
+scripts = ['bother']
+
+if os.name == 'nt':
+    scripts.append(os.path.join('scripts', 'bother.bat'))
+    
 setup(
     name='Bother',
     version='0.1',
     packages=find_packages(),
-    scripts=['bother'],
+    scripts=scripts,
     install_requires=['numpy', 'rasterio', 'pillow', 'requests', 'appdirs'],
     package_data={},
     author='bunburya',


### PR DESCRIPTION
Adds a small batch file allowing the 'bother' CLI command to be picked up on Windows, as it doesn't naturally pick up on how to execute 'bother' after install.