### PR TITLE
Fix behaviour for nested cache dir paths

### DIFF
--- a/bother_utils/srtm.py
+++ b/bother_utils/srtm.py
@@ -128,8 +128,7 @@ def fetch_all_zips(fnames: Dict[Tuple[int, int], str], cache_dir: str) -> Dict[T
 
 def unzip_all(zip_files: Iterable[str], cache_dir: str) -> str:
     extract_dir = get_extract_dir(cache_dir)
-    if not os.path.exists(extract_dir):
-        os.mkdir(extract_dir)
+    os.makedirs(extract_dir, exist_ok=True)
     for fpath in zip_files:
         if fpath is not None:
             print(f'Extracting {fpath} to {extract_dir}.')
@@ -145,8 +144,7 @@ def create_tif_file(left: float, bottom: float, right: float, top: float, to_fil
     rasterio.io.MemoryFile and returns that.
     """
     
-    if not os.path.exists(cache_dir):
-        os.mkdir(cache_dir)
+    os.makedirs(cache_dir, exist_ok=True)
     
     xy = get_all_xy_components(left, bottom, right, top)
     zip_fnames = {}

--- a/test/test_bother.py
+++ b/test/test_bother.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-sys.path.append(sys.argv[1])
+# sys.path.append(sys.argv[1])
 
 import unittest
 import os
@@ -16,8 +16,8 @@ from bother_utils.heightmap import *
 from bother_utils.srtm import *
 
 
-EXAMPLES_DIR = 'examples'
-TEST_DIR = 'test_data'
+EXAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'examples')
+TEST_DIR = os.path.join(os.path.dirname(__file__), 'test_data')
 
 test_coords = {
     'mallorca': (39.195468, 2.272535, 39.998336, 3.584351),
@@ -111,7 +111,7 @@ class BotherTestCase(unittest.TestCase):
         Also tests reprojection and upsampling of data.
         """
                 
-        with open(os.path.join(TEST_DIR, 'titicaca.tif'), 'rb') as f:
+        with open(os.path.join(EXAMPLES_DIR, 'titicaca.tif'), 'rb') as f:
             memfile = MemoryFile(f)
             memfile = reproject_raster(memfile, dst_crs='EPSG:3857')
             memfile = set_lakes_to_elev(memfile, min_lake_size=80)
@@ -119,11 +119,21 @@ class BotherTestCase(unittest.TestCase):
         with Image.open(os.path.join(EXAMPLES_DIR, 'titicaca_lakes_3857.png')) as im2:
             self._assert_images_equal(im1, im2)
         
-        with open(os.path.join(TEST_DIR, 'alps.tif'), 'rb') as f:
+        with open(os.path.join(EXAMPLES_DIR, 'alps.tif'), 'rb') as f:
             memfile = MemoryFile(f)
             im1 = to_png(memfile)
         with Image.open(os.path.join(EXAMPLES_DIR, 'alps.png')) as im2:
             self._assert_images_equal(im1, im2)
+    
+    def test_5_nested_cache_dir(self):
+        """Test cache directory creation when multiple levels of the cache path do not exist."""
+        
+        bottom, left, top, right = test_coords["mallorca"]
+        cache_dir = os.path.join(TEST_DIR, "level1", "level2")
+        tif_file = os.path.join(TEST_DIR, f'mallorca.tif')
+        eg_tif_file = os.path.join(EXAMPLES_DIR, f'mallorca.tif')
+        create_tif_file(left, bottom, right, top, os.path.abspath(tif_file), cache_dir=cache_dir)
+        self._assert_image_files_equal(tif_file, eg_tif_file)
 
 if __name__ == '__main__':
-    unittest.main(argv=['hi'])
+    unittest.main()


### PR DESCRIPTION
Handle the case where the cache directory's parent directory also doesn't exist (etc.).

Something new to me - on Windows, calling `appdirs.user_cache_dir('bother')` returns a path like `C:\Users\<username>\AppData\Local\bother\Cache`. The `bother` level is not automatically created, and `os.mkdir` gets upset when it tries to create `Cache`. Easy change - just use `os.makedirs`, which will create the whole directory tree as needed, and also avoids the need to do a check for whether the directory exists before creating.

I slightly modified the tests to make them behave better with `pytest` - mostly just tidying up how it looks for paths.