### PR TITLE
Download progress bar

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,5 +11,6 @@ rasterio = "*"
 pillow = "*"
 appdirs = "*"
 requests = "*"
+tqdm = "*"
 
 [requires]

--- a/bother_utils/srtm.py
+++ b/bother_utils/srtm.py
@@ -59,11 +59,16 @@ def download_zip(url: str, save_path: str, chunk_size: int = 1024):
     r = requests.get(url, stream=True)
     r.raise_for_status()
     total_size_in_bytes = int(r.headers.get('content-length', 0))
+    
+    # Write to a temporary file so that incompletely downloaded tiles are
+    # not considered to have been cached
+    temp_save_path = save_path + ".part"
     with tqdm(total=total_size_in_bytes, unit='iB', unit_scale=True) as pbar:
-        with open(save_path, 'wb') as fd:
+        with open(temp_save_path, 'wb') as fd:
             for chunk in r.iter_content(chunk_size=chunk_size):
                 pbar.update(len(chunk))
                 fd.write(chunk)
+    os.rename(temp_save_path, save_path)
     return save_path
 
 def get_xy_components(lon: float, lat: float) -> Tuple[int, int]:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='0.1',
     packages=find_packages(),
     scripts=['bother'],
-    install_requires=['numpy', 'rasterio', 'pillow', 'requests', 'appdirs'],
+    install_requires=['numpy', 'rasterio', 'pillow', 'requests', 'appdirs', 'tqdm'],
     package_data={},
     author='bunburya',
     author_email='',


### PR DESCRIPTION
Not a bug fix this time!

Adds a little progress bar to each file download, as each individual tile takes 3-4 minutes for me (I don't think the SRTM servers are particularly speedy), and it's nice to see that something is still happening.

I did make one minor functional change, to download to <filename>.part, and only rename on a complete download. As the data is now streamed to file while downloading, killing the program (or encountering network issues, or an error) would result in a part-downloaded tile being left in the cache directory, and considered as fully downloaded on future iterations. One could probably invent an even neater solution, but hey, it works.